### PR TITLE
Use GITHUB_REF_NAME as name of push branch; fix error in branch detection [citest skip]

### DIFF
--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -1,5 +1,5 @@
 # yamllint disable rule:line-length
-name: Pushing CHANGELOG.md triggers tagging
+name: Pushing CHANGELOG.md triggers tag, release, and Galaxy publish
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # This token is provided by Actions, you do not need to create your own token
 jobs:
-  tagging:
+  tag_release_publish:
     runs-on: ubuntu-latest
     steps:
       - name: checkout PR
@@ -19,27 +19,46 @@ jobs:
         id: tag
         run: |
           set -euxo pipefail
-          pat='\[[0-9]*\.[0-9]*\.[0-9]*\] - [0-9\-]*'
           print=false
-          cat CHANGELOG.md | while read -r line; do
-              if [[ $line =~ $pat ]] && [[ $print == false ]]; then
-                  echo $line
-                  print=true
-              elif [[ $line =~ $pat ]] && [[ $print == true ]]; then
-                  break
-              elif [[ $print == true ]]; then
-                  echo $line
+          while read -r line; do
+              if [[ "$line" =~ ^\[([0-9]+\.[0-9]+\.[0-9]+)\]\ -\ [0-9-]+ ]]; then
+                  if [ "$print" = false ]; then
+                      _tagname="${BASH_REMATCH[1]}"
+                      echo "$line"
+                      print=true
+                  else
+                      break
+                  fi
+              elif [ "$print" = true ]; then
+                  echo "$line"
               fi
-          done > ./.tagmsg.txt
-          _tagname=$( grep -m 1 "[0-9]*\.[0-9]*\.[0-9]*" CHANGELOG.md | sed -e "s/^.*\[\([0-9]*\.[0-9]*\.[0-9]*\)\].*/\1/" )
+          done < CHANGELOG.md > ./.tagmsg.txt
           git fetch --all --tags
           for t in $( git tag -l ); do
-              if [[ $t == "$_tagname" ]]; then
-                  echo INFO: tag $t already exists
+              if [ "$t" = "$_tagname" ]; then
+                  echo INFO: tag "$t" already exists
                   exit 1
               fi
           done
+          # Get name of the branch that the change was pushed to
+          _branch="${GITHUB_REF_NAME:-}"
+          if [ "$_branch" = master ] || [ "$_branch" = main ]; then
+              echo Using branch name ["$_branch"] as push branch
+          else
+              echo WARNING: GITHUB_REF_NAME ["$_branch"] is not main or master
+              _branch=$( git branch -r | grep -o 'origin/HEAD -> origin/.*$' | \
+                         awk -F'/' '{print $3}' || : )
+          fi
+          if [ -z "$_branch" ]; then
+              _branch=$( git branch --points-at HEAD --no-color --format='%(refname:short)' )
+          fi
+          if [ -z "$_branch" ]; then
+              echo ERROR: unable to determine push branch
+              git branch -a
+              exit 1
+          fi
           echo ::set-output name=tagname::"$_tagname"
+          echo ::set-output name=branch::"$_branch"
       - name: Create tag
         uses: mathieudutour/github-tag-action@v6.0
         with:
@@ -59,3 +78,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.2.0
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
+          git_branch: ${{ steps.tag.outputs.branch }}


### PR DESCRIPTION
We need to get the name of the branch to which CHANGELOG.md was pushed.
For now, it looks as though `GITHUB_REF_NAME` is that name.  But don't
trust it - first, check that it is `main` or `master`.  If not, then use
a couple of other methods to determine what is the push branch.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
