### PR TITLE
[citest skip] tox-lsr 2.13.0; check-meta-versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -3,7 +3,7 @@ name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.11.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.13.0"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -40,6 +40,6 @@ jobs:
           36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck" ;;
           38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
           39) toxenvs="${toxenvs},coveralls,ansible-managed-var-comment" ;;
-          310) toxenvs="${toxenvs},coveralls,custom" ;;
+          310) toxenvs="${toxenvs},coveralls,custom,check-meta-versions" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,5 +15,5 @@ galaxy_info:
         - 7
         - 8
         - 9
-  galaxy_tags: [pam,password,policy]
+  galaxy_tags: [pam, password, policy]
 dependencies: []


### PR DESCRIPTION
Update to tox-lsr 2.13.0 - this adds check-meta-versions to py310

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
