### PR TITLE
ansible-lint - use changed_when on conditional tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,4 @@
 - name: Apply authselect changes
   listen: pam_pwd_authselect_apply
   command: authselect apply-changes
+  changed_when: true

--- a/tasks/setup/default.yml
+++ b/tasks/setup/default.yml
@@ -41,6 +41,7 @@
   command: authselect create-profile {{ pam_pwd_policy_name }} -b sssd
   notify: pam_pwd_authselect_apply
   when: not pam_pwd_policy_name in __pam_pwd_authselect_list.stdout
+  changed_when: true
 
 - name: List authselect current profile
   command: authselect current
@@ -58,6 +59,7 @@
   command: authselect select --force custom/{{ pam_pwd_policy_name }}
   notify: pam_pwd_authselect_apply
   when: not pam_pwd_policy_name in __pam_pwd_authselect_current.stdout
+  changed_when: true
 
 - name: List authselect current profile
   command: authselect current
@@ -68,6 +70,7 @@
   command: authselect enable-feature with-faillock
   notify: pam_pwd_authselect_apply
   when: not "with-faillock" in __pam_pwd_authselect_features.stdout
+  changed_when: true
 
 - name: Keep history of the last passwords used num {{ pam_pwd_history }}
   lineinfile:


### PR DESCRIPTION
ansible-lint requires use of changed_when on conditional tasks

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
