### PR TITLE
docs: remove unused Dependencies section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,15 @@ pam_pwd_unlock_time: "300" # Time in seconds after which an account is unlocked 
 
 You can keep these default values if they fit your requirements. Or you can overwrite the defaults by specifiny some or all of them in places like `vars/main.yml`, `group_vars/`, `host_vars/` or your playbook.
 
-## Dependencies
-
-None.
-
 ## Example Playbook
 
 The following code block shows the simplest playbook to run this role:
 
 ```yaml
-- hosts: all
+- name: Manage pam password
+  hosts: all
   roles:
-    - pam_pwd
+    - linux-system-roles.pam_pwd
 ```
 
 More examples can be found in the [`examples/`](examples) directory.


### PR DESCRIPTION
remove unused Dependencies section in README - it is confusing
to users who look at the README, see the `Dependencies` section
that says `None`, and think that there are no dependencies for
the role, when the actual dependencies are listed in the
`Requirements` section which is not even near the `Dependencies`
section.  So consistently use the `Requirements` section and
get rid of the `Dependencies` section.

Fix some ansible-lint issues

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
