### PR TITLE
ci: Add pull request template and run commitlint on PR title only

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Enhancement:
+
+Reason:
+
+Result:
+
+Issue Tracker Tickets (Jira or BZ if any):

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -24,20 +24,6 @@ jobs:
       - name: Install conventional-commit linter
         run: npm install @commitlint/config-conventional @commitlint/cli
 
-      # Finding the commit range is not as trivial as it may seem.
-      #
-      # At this stage, git's HEAD does not refer to the latest commit in the
-      # PR, but rather to the merge commit inserted by the PR. So instead we
-      # have to get 'HEAD' from the PR event.
-      #
-      # One cannot use the number of commits
-      # (github.event.pull_request.commits) to find the start commit
-      # i.e. HEAD~N does not work, this breaks if there are merge commits.
-      - name: Run commitlint on commits
-        run: >-
-          npx commitlint --from '${{ github.event.pull_request.base.sha }}'
-          --to '${{ github.event.pull_request.head.sha }}' --verbose
-
       - name: Run commitlint on PR title
         run: >-
           echo '${{ github.event.pull_request.title }}' |


### PR DESCRIPTION
We now ensure the conventional commits format only on PR titles and not on
commits to let developers keep commit messages targeted for other developers
i.e. describe actual changes to code that users should not care about.
And PR titles, on the contrary, must be aimed at end users.

For more info, see
https://linux-system-roles.github.io/contribute.html#write-a-good-pr-title-and-description

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
