### PR TITLE
ci: tox-lsr 3.4.0 - fix py27 tests; move other checks to py310

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: default
 ignore: |
   /.tox/

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,6 @@
 # Put handlers for tasks here.
 
 - name: Apply authselect changes
-  listen: pam_pwd_authselect_apply
+  listen: Pam_pwd_authselect_apply
   command: authselect apply-changes
   changed_when: true

--- a/tasks/setup/default.yml
+++ b/tasks/setup/default.yml
@@ -39,7 +39,7 @@
     Create custom authselect profile
     from existing profile sssd {{ pam_pwd_policy_name }}
   command: authselect create-profile {{ pam_pwd_policy_name }} -b sssd
-  notify: pam_pwd_authselect_apply
+  notify: Pam_pwd_authselect_apply
   when: not pam_pwd_policy_name in __pam_pwd_authselect_list.stdout
   changed_when: true
 
@@ -57,7 +57,7 @@
 # to configure authselect
 - name: Select profile {{ pam_pwd_policy_name }}
   command: authselect select --force custom/{{ pam_pwd_policy_name }}
-  notify: pam_pwd_authselect_apply
+  notify: Pam_pwd_authselect_apply
   when: not pam_pwd_policy_name in __pam_pwd_authselect_current.stdout
   changed_when: true
 
@@ -68,7 +68,7 @@
 
 - name: Set enable-feature with-faillock
   command: authselect enable-feature with-faillock
-  notify: pam_pwd_authselect_apply
+  notify: Pam_pwd_authselect_apply
   when: not "with-faillock" in __pam_pwd_authselect_features.stdout
   changed_when: true
 


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  Change our CI tests to restrict the version
of virtualenv<20.22.0 and tox<4.15 for py27 environments

Move pylint, flake8, and black checks to the py310 environment
which is currently supported by ansible-core 2.17 and its related
checkers such as ansible-lint and ansible-test

pylint now uses ansible-core 2.17 and restricts the version of
pylint to 3.1.0 which is the version used by ansible-test 2.17

Remove `extends: default` for .yamllint.yml.  The latest version
of ansible-lint will automatically incorporate local yamllint
settings unless there is an `extends:`.

The above changes require some fixes to the role code.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168
and
https://github.com/linux-system-roles/tox-lsr/pull/170

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
