### PR TITLE
refactor: Use vars/RedHat_N.yml symlink for CentOS, Rocky, Alma wherever possible

### DIFF
--- a/tests/vars/redhat_clone_vars.yml
+++ b/tests/vars/redhat_clone_vars.yml
@@ -1,19 +1,5 @@
-# SPDX-License-Identifier: MIT
+# vars for handling conditionals for RedHat and clones
 ---
-# defaults file for password-policy
-pam_pwd_minlen: "12"
-pam_pwd_history: "10"
-pam_pwd_dcredit: "-1"
-pam_pwd_ucredit: "-1"
-pam_pwd_lcredit: "-1"
-pam_pwd_ocredit: "-1"
-pam_pwd_minclass: "4"
-pam_pwd_enforce_root: "enforce_for_root"
-pam_pwd_policy_name: "password-policy"
-pam_pwd_deny: "5"
-pam_pwd_unlock_time: "300"
-
-# BEGIN redhat distros variables
 # Ansible distribution identifiers that the role treats like RHEL
 __pam_pwd_rh_distros:
   - AlmaLinux
@@ -25,7 +11,5 @@ __pam_pwd_rh_distros:
 __pam_pwd_rh_distros_fedora: "{{ __pam_pwd_rh_distros + ['Fedora'] }}"
 # Use this in conditionals to check if distro is Red Hat or clone
 __pam_pwd_is_rh_distro: "{{ ansible_distribution in __pam_pwd_rh_distros }}"
-
 # Use this in conditionals to check if distro is Red Hat or clone, or Fedora
 __pam_pwd_is_rh_distro_fedora: "{{ ansible_distribution in __pam_pwd_rh_distros_fedora }}"
-# END redhat distros variables


### PR DESCRIPTION
We have a lot of requests to support Rocky and Alma in various system roles. The
first part of adding support is adding `vars/` files for these platforms. In
almost every case, for a given major version N, the vars file RedHat_N.yml can
be used for CentOS, Rocky, and Alma.  Rather than making a copy of the
RedHat_N.yml file, just use a symlink to reduce size and maintenance burden, and
standardize this across all system roles for consistency.

NOTE: OracleLinux is not a strict clone, so we are not going to do this for
OracleLinux at this time.  Support for OracleLinux will need to be done in
separate PRs. For more information, see
https://github.com/linux-system-roles/cockpit/issues/130

Note that there may be more work to be done to the role to fully support Rocky
and Alma.  Many roles have conditionals like this:

```yaml
some_var: "{{ 'some value' if ansible_distribution in ['CentOS', 'RedHat'] else 'other value' }}"
another_var: "{{ 'some value' if ansible_distribution in ['CentOS', 'Fedora', 'RedHat'] else 'other value' }}"

...

- name: Do something
  when: ansible_distribution in ['CentOS', 'RedHat']
  ...
- name: Do something else
  when: ansible_distribution in ['CentOS', 'Fedora', 'RedHat']
  ...
```

Adding Rocky and AlmaLinux to these conditionals will have to be done
separately. In order to simplify the task, some new variables are being
introduced:

```yaml
__$rolename_rh_distros:
  - AlmaLinux
  - CentOS
  - RedHat
  - Rocky

__$rolename_rh_distros_fedora: "{{ __$rolename_rh_distros + ['Fedora'] }}"

__$rolename_is_redhat_distro: "{{ ansible_distribution in __$rolename_rh_distros }}"
__$rolename_is_redhat_distro_fedora: "{{ ansible_distribution in __$rolename_rh_distros_fedora }}"
```

Then the conditionals can be rewritten as:

```yaml
some_var: "{{ 'some value' if __$rolename_is_redhat_distro else 'other value' }}"
another_var: "{{ 'some value' if __$rolename_is_redhat_distro_fedora else 'other value' }}"

...

- name: Do something
  when: __$rolename_is_redhat_distro | bool
  ...
- name: Do something else
  when: __$rolename_is_redhat_distro_fedora | bool
  ...
```

For tests - tests that use such conditionals will need to use `vars_files` or
`include_vars` to load the variables that are defined in
`tests/vars/redhat_clone_vars.yml`:

```yaml
vars_files:
  - vars/redhat_clone_vars.yml
```

We don't currently have CI testing for Rocky or Alma, so someone wanting to run
tests on those platforms would need to change the test code to use these.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
