### PR TITLE
feat: Support this role in container environments and builds

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,4 +24,6 @@ galaxy_info:
     - pam
     - password
     - policy
+    - container
+    - containerbuild
 dependencies: []


### PR DESCRIPTION
Feature: Support running the pam_pwd role during container builds and in
container environments.

Reason: This is particularly useful for building bootc derivative OSes.
It's also desirable to run roles in system containers.

Result: These flags enable running the container scenarios in CI, which
ensures that the role works in podman system containers as well as
buildah build environment and thus allows us to officially support this
role for image mode builds.

See https://issues.redhat.com/browse/RHEL-78157

## Summary by Sourcery

Add metadata tags to enable running the pam_pwd Ansible role in container environments and build environments

New Features:
- Support container scenario by tagging role with 'container' and 'containerbuild'

Enhancements:
- Allow CI workflows to execute container-based tests using podman and buildah