### PR TITLE
tests: Add an actual integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pam_pwd_lcredit: "-1" # defines minimum credit for having lowercase characters i
 pam_pwd_ocredit: "-1" # defines minimum credit for having other characters in password.
 pam_pwd_minclass: "4" # defines minimum number of required character classes in new password.
 pam_pwd_enforce_root: "enforce_for_root" # (""|"enforce_for_root") defines whether or not to enforce password complexity for user root.
-pam_pwd_policy_name: "password-policy" # RHEL 8 only. Define name of the custom authselect profile.
+pam_pwd_policy_name: "password-policy" # Define name of the custom authselect profile. Not available on RHEL 7.
 pam_pwd_deny: "5" # Set the number of failed login attempts after which the account is locked.
 pam_pwd_unlock_time: "300" # Time in seconds after which an account is unlocked again.
 ```

--- a/tasks/setup/default.yml
+++ b/tasks/setup/default.yml
@@ -24,6 +24,11 @@
     state: present
     backup: true
 
+- name: Ensure authselect is installed
+  package:
+    name: authselect
+    state: present
+
 # I use the command module because I don't know a better alternative
 # to configure authselect
 - name: List authselect profiles

--- a/tests/tests_all_settings.yml
+++ b/tests/tests_all_settings.yml
@@ -23,9 +23,17 @@
         # /etc/security/faillock.conf settings
         pam_pwd_deny: "5"
         pam_pwd_unlock_time: "300"
+      when: not __bootc_validation | d(false)
 
     - name: Flush handlers
       meta: flush_handlers
+
+    - name: Create QEMU deployment during bootc end-to-end test
+      delegate_to: localhost
+      become: false
+      command: "{{ lsr_scriptdir }}/bootc-buildah-qcow.sh {{ ansible_host }}"
+      changed_when: true
+      when: ansible_connection == "buildah"
 
     - name: Get custom settings from pwquality.conf
       command: cat /etc/security/pwquality.conf

--- a/tests/tests_all_settings.yml
+++ b/tests/tests_all_settings.yml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Test role with all settings
+  hosts: all
+
+  tasks:
+    - name: Run the role
+      include_role:
+        name: linux-system-roles.pam_pwd
+      vars:
+        # /etc/security/pwquality.conf settings
+        pam_pwd_minlen: "12"
+        pam_pwd_dcredit: "-1"
+        pam_pwd_ucredit: "-2"
+        pam_pwd_lcredit: "-3"
+        pam_pwd_ocredit: "-4"
+        pam_pwd_minclass: "4"
+
+        # PAM config settings
+        pam_pwd_history: "10"
+        pam_pwd_enforce_root: "enforce_for_root"
+
+        # /etc/security/faillock.conf settings
+        pam_pwd_deny: "5"
+        pam_pwd_unlock_time: "300"
+
+    - name: Flush handlers
+      meta: flush_handlers
+
+    - name: Get custom settings from pwquality.conf
+      command: cat /etc/security/pwquality.conf
+      register: pwquality_conf
+      changed_when: false
+
+    - name: Check pwquality.conf settings
+      assert:
+        that:
+          - "'minlen = 12' in pwquality_conf.stdout_lines"
+          - "'dcredit = -1' in pwquality_conf.stdout_lines"
+          - "'ucredit = -2' in pwquality_conf.stdout_lines"
+          - "'lcredit = -3' in pwquality_conf.stdout_lines"
+          - "'ocredit = -4' in pwquality_conf.stdout_lines"
+          - "'minclass = 4' in pwquality_conf.stdout_lines"
+
+    - name: Read PAM config files
+      command: "cat {{ item }}"
+      register: pam_conf
+      changed_when: false
+      loop:
+        # /etc/pam.d/* are authselect symlinks (on anything but RHEL 7), check the effective end result
+        - /etc/pam.d/password-auth
+        - /etc/pam.d/system-auth
+
+    - name: Verify PAM config file settings
+      assert:
+        that:
+          - item.stdout is search('pam_pwhistory.so.*remember=10')
+          - item.stdout is search('pam_pwquality.so.*enforce_for_root')
+      loop: "{{ pam_conf.results }}"
+
+    - name: Validate faillock.conf settings on OSes other than RHEL 7
+      when: ansible_facts['os_family'] != 'RedHat' or
+            ansible_facts.distribution_major_version != '7'
+      block:
+        - name: Get faillock.conf settings
+          command: cat /etc/security/faillock.conf
+          register: faillock_conf
+          changed_when: false
+
+        - name: Check faillock.conf settings
+          assert:
+            that:
+              - "'deny=5' in faillock_conf.stdout_lines"
+              - "'unlock_time=300' in faillock_conf.stdout_lines"


### PR DESCRIPTION
tests_default.yml doesn't actually do anything other than making sure that the role succees. It does not have any assertions.

Add tests_all_settings.yml based on examples/playbook_with_vars.yml which validates that the role has the desired effect.

This uncovers a bug that the custom authselect policy is not applied properly.

----

Yak shaving - I was about to add a [bootc end-to-end test](https://issues.redhat.com/browse/RHEL-78157), then noticed that this role is lacking a test, and wrote one.

## Summary by Sourcery

Add a comprehensive integration test for the pam_pwd role that applies all configuration options and verifies the resulting pwquality, PAM, and faillock settings, and ensure the authselect package is installed before configuring policies.

Bug Fixes:
- Ensure authselect package is installed prior to configuring custom policies

Documentation:
- Clarify platform availability for pam_pwd_policy_name setting in README

Tests:
- Introduce tests_all_settings.yml to run the role with all parameters and assert pwquality.conf, PAM profiles, and faillock.conf